### PR TITLE
Move SBOM generation to separate job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,21 +132,33 @@ jobs:
         with:
           name: release-artifacts
           path: upt*.zip
-  upload-artifacts:
-    name: "Upload binaries to release"
+  sbom:
+    name: "Generate SBOM"
     runs-on: "ubuntu-latest"
-    needs: [ "build-release" ]
-    outputs:
-      digests: ${{ steps.hash.outputs.hashes }}
-    permissions:
-      contents: write
+    needs: [ "release-tag" ]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
       - name: "Create SBOM"
         uses: anchore/sbom-action@v0
         with:
+          upload-artifact: false
+          upload-release-assets: false
           output-file: ./upt-release-sbom.spdx.json
+      - name: "Upload SBOM artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-artifacts
+          path: upt-release-sbom.spdx.json
+  upload-artifacts:
+    name: "Upload binaries to release"
+    runs-on: "ubuntu-latest"
+    needs: [ "build-release", "sbom" ]
+    outputs:
+      digests: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: write
+    steps:
       - uses: actions/download-artifact@v3
         with:
           name: release-artifacts
@@ -155,7 +167,6 @@ jobs:
         id: hash
         run: |
           set -exuo pipefail
-          cp upt-release-sbom* binaries/
           # List the artifacts the provenance will refer to.
           cd binaries
           ls -al
@@ -166,8 +177,6 @@ jobs:
           files=$(ls upt*)
           # Generate the subjects (base64 encoded).
           echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
-          # the sbom action already uploaded this file, let's not upload it twice:
-          rm upt-release-sbom*
       - name: "Upload binaries to release"
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
This way it simplifies the artifact upload to release. The names used for release artifacts and hashed files will aslo be consistent. (Previously different names were used for the file name and the artifact name by anchrone/sbom-action)