### PR TITLE
Use single carriage returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "upt"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "chrono-humanize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upt"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,16 +80,12 @@ fn render_duration(start: DateTime<Utc>, iso: bool) -> String {
 
 /// Overwrite the previous line when printing the next one, passing the length of the line to be overwritten
 fn clear_line(line_length: usize) {
-    for _i in 0..line_length {
-        print!("\r")
-    }
+    print!("\r");
     for _i in 0..line_length {
         // clear the line with spaces in case the next line is shorter
         print!(" ")
     }
-    for _i in 0..line_length {
-        print!("\r")
-    }
+    print!("\r")
 }
 
 use std::error::Error;


### PR DESCRIPTION
Since printing multiple carriage returns are equivalent to printing just a single carriage return any additional ones are redundant.
With this PR we change the `clear_line` method to only print single carriage returns.

Closes #13