### PR TITLE
Update missing action/download-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: "binaries"
           pattern: release-artifacts-*


### PR DESCRIPTION
This is needed to be able to get the uploaded artifacts.